### PR TITLE
convertページの説明の幅調整

### DIFF
--- a/app/views/stone_converter/convert.html.erb
+++ b/app/views/stone_converter/convert.html.erb
@@ -34,7 +34,7 @@
   </p>
 
   <!-- 説明 -->
-  <p id="stone-description" class="mx-auto max-w-sm text-xs font-mono text-gray-500 leading-relaxed">
+  <p id="stone-description" class="mx-auto max-w-sm px-10 text-xs font-mono text-gray-500 leading-relaxed">
     <%= @stone.description %>
   </p>
 


### PR DESCRIPTION
- スマホだとかなり端まで「説明」が広がってしまうのでパディングを追加。